### PR TITLE
fix: rules not applied properly if using array

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -5,7 +5,7 @@ import type { Rule } from './types'
 
 export type ModuleOptions = {
   configPath: string,
-  rules: Rule | Rule[]
+  rules?: Rule | Rule[]
 }
 
 const ROBOTS_FILENAME = 'robots.txt'
@@ -22,10 +22,6 @@ export default defineNuxtModule<ModuleOptions>({
   },
   defaults: {
     configPath: 'robots.config',
-    rules: {
-      UserAgent: '*',
-      Disallow: ''
-    }
   },
   async setup (options, nuxt) {
     const { resolve } = createResolver(import.meta.url)
@@ -35,6 +31,15 @@ export default defineNuxtModule<ModuleOptions>({
       isNuxt2() ? nuxt.options.dir.static : nuxt.options.dir.public,
       ROBOTS_FILENAME
     )
+
+    if (!options.rules) {
+      options.rules = [
+        {
+          UserAgent: '*',
+          Disallow: ''
+        }
+      ]
+    }
 
     if (existsSync(staticFilePath)) {
       logger.warn('To use `' + name + '` module, please remove public `robots.txt`')


### PR DESCRIPTION
Issue discussed here #97 
The default rules is an object. If the config passing an array it will causing it discarded.
I didn't dig deeper on how Nuxt applying the default option but this is a quick fix for the issue.