### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 1. Add `@nuxtjs/robots` dependency to your project
 
 ```bash
-yarn add @nuxtjs/robots # or npm install @nuxtjs/robots
+npx nuxi@latest module add robots
 ```
 
 2. Add `@nuxtjs/robots` to the `modules` section of `nuxt.config.js`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
