### PR TITLE
ci: add codecov token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,5 @@ jobs:
 
       - name: 🟩 Coverage
         uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,6 @@ jobs:
         run: pnpm test
 
       - name: 🟩 Coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
with v4 of the codecov action, we need to supply a codecov token (pointed out by @ricardogobbosouza). I've added the token in GH variables...