### PR TITLE
feat: `header`, disable setting `X-Robots-Tag` header

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -30,6 +30,12 @@ export interface ModuleOptions {
    */
   enabled: boolean
   /**
+   * Should a `X-Robots-Tag` header be added to the response.
+   *
+   * @default true
+   */
+  header: boolean
+  /**
    * Should a `<meta name="robots" content="<>">` tag be added to the head.
    *
    * @default true
@@ -161,6 +167,7 @@ export default defineNuxtModule<ModuleOptions>({
     groups: [],
     blockNonSeoBots: false,
     mergeWithRobotsTxtPath: true,
+    header: true,
     metaTag: true,
     cacheControl: 'max-age=14400, must-revalidate',
     robotsEnabledValue: 'index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1',
@@ -362,18 +369,20 @@ export default defineNuxtModule<ModuleOptions>({
 
       nuxt.options.routeRules = nuxt.options.routeRules || {}
       // convert robot routeRules to header routeRules for static hosting
-      Object.entries(nuxt.options.routeRules).forEach(([route, rules]) => {
-        const url = route.split('/').map(segment => segment.startsWith(':') ? '*' : segment).join('/')
-        const groupIndexable = indexableFromGroup(config.groups, url)
-        const robotRules = normaliseRobotsRouteRule(rules, groupIndexable, config.robotsDisabledValue, config.robotsEnabledValue)
-        // single * is supported but ignored
-        // @ts-expect-error untyped
-        nuxt.options.routeRules[route] = defu({
-          headers: {
-            'X-Robots-Tag': robotRules.rule,
-          },
-        }, nuxt.options.routeRules?.[route])
-      })
+      if (config.header) {
+        Object.entries(nuxt.options.routeRules).forEach(([route, rules]) => {
+          const url = route.split('/').map(segment => segment.startsWith(':') ? '*' : segment).join('/')
+          const groupIndexable = indexableFromGroup(config.groups, url)
+          const robotRules = normaliseRobotsRouteRule(rules, groupIndexable, config.robotsDisabledValue, config.robotsEnabledValue)
+          // single * is supported but ignored
+          // @ts-expect-error untyped
+          nuxt.options.routeRules[route] = defu({
+            headers: {
+              'X-Robots-Tag': robotRules.rule,
+            },
+          }, nuxt.options.routeRules?.[route])
+        })
+      }
 
       const extraDisallows = new Set<string>()
       if (config.disallowNonIndexableRoutes) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -417,6 +417,7 @@ export default defineNuxtModule<ModuleOptions>({
         credits: config.credits,
         groups: config.groups,
         sitemap: config.sitemap,
+        header: config.header,
         robotsEnabledValue: config.robotsEnabledValue,
         robotsDisabledValue: config.robotsDisabledValue,
         // @ts-expect-error untyped

--- a/src/runtime/nitro/server/middleware.ts
+++ b/src/runtime/nitro/server/middleware.ts
@@ -1,10 +1,14 @@
 import { defineEventHandler, setHeader } from 'h3'
 import { getPathRobotConfig } from '#internal/nuxt-robots'
+import { useRuntimeConfig } from '#imports'
 
 export default defineEventHandler(async (e) => {
   if (e.path === '/robots.txt' || e.path.startsWith('/__') || e.path.startsWith('/api') || e.path.startsWith('/_nuxt'))
     return
   const robotConfig = getPathRobotConfig(e)
-  setHeader(e, 'X-Robots-Tag', robotConfig.rule)
+  const { header } = useRuntimeConfig(e)['nuxt-robots']
+  if (header) {
+    setHeader(e, 'X-Robots-Tag', robotConfig.rule)
+  }
   e.context.robots = robotConfig
 })

--- a/src/runtime/nuxt/composables/useRobotsRule.ts
+++ b/src/runtime/nuxt/composables/useRobotsRule.ts
@@ -37,7 +37,9 @@ export function useRobotsRule(rule?: MaybeRef<boolean | string>) {
       _rule = _rule ? config['nuxt-robots'].robotsEnabledValue : config['nuxt-robots'].robotsDisabledValue
     }
     event.context.robots.rule = _rule
-    setHeader(event, 'X-Robots-Tag', _rule)
+    if (config['nuxt-robots'].header) {
+      setHeader(event, 'X-Robots-Tag', _rule)
+    }
     useServerHead({
       meta: [
         {

--- a/test/noHeader.test.ts
+++ b/test/noHeader.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { setup } from '@nuxt/test-utils'
+import { createResolver } from '@nuxt/kit'
+
+const { resolve } = createResolver(import.meta.url)
+
+process.env.NODE_ENV = 'production'
+await setup({
+  rootDir: resolve('../.playground'),
+  build: true,
+  nuxtConfig: {
+    robots: {
+      debug: true,
+      header: false,
+    },
+  },
+})
+
+describe('noHeader', () => {
+  it('basic', async () => {
+    const { headers, _data } = await $fetch.raw('/')
+    expect(headers.get('X-Robots-Tag')).toBe(null)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

resolves #133 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->

Add an option to disable setting `X-Robots-Tag` header.
