### PR TITLE
fix: comments being treated as errors

### DIFF
--- a/src/runtime/util.ts
+++ b/src/runtime/util.ts
@@ -31,8 +31,9 @@ export function parseRobotsTxt(s: string): ParsedRobotsTxt {
   }
   let ln = -1
   // read the contents
-  for (const line of s.split('\n')) {
+  for (const _line of s.split('\n')) {
     ln++
+    const [line, comment] = _line.split('#').map(s => s.trim())
     const sepIndex = line.indexOf(':')
     // may not exist for comments
     if (sepIndex === -1)

--- a/test/fixtures/comments.txt
+++ b/test/fixtures/comments.txt
@@ -1,0 +1,4 @@
+# line comment
+
+User-agent: *   # 1st inline comment
+Allow: /        # 2nd inline comment

--- a/test/unit/robotsTxtParser.test.ts
+++ b/test/unit/robotsTxtParser.test.ts
@@ -355,4 +355,26 @@ Unknown: /bar
       ]
     `)
   })
+
+  it('comments do not error', async () => {
+    const robotsTxt = await fsp.readFile('./test/fixtures/comments.txt', { encoding: 'utf-8' })
+    expect(parseRobotsTxt(robotsTxt)).toMatchInlineSnapshot(`
+      {
+        "errors": [],
+        "groups": [
+          {
+            "allow": [
+              "/",
+            ],
+            "comment": [],
+            "disallow": [],
+            "userAgent": [
+              "*",
+            ],
+          },
+        ],
+        "sitemaps": [],
+      }
+    `)
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Fixing this was easier than opening an issue 😇 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR prevents the module from treating comments as errors and logging them to the console.

I looked into pushing the comments to `currentGroup.comments.push(comment)` to later restore them but, as mentioned in your comment (`comments are too hard to parse in a logical order, we'll just omit them`), it makes things unnecessarily complicated and would require rewriting other parts of the module. Plus I would count getting rid of them as minification so I'm guessing it's a good thing.

I believe we can get rid of `currentGroup.comment` and the `for` loop where we restore the comments since we're not saving them at any point. Might have a very minor positive impact on sites with a big `robots.txt` file.