### PR TITLE
fix: support missing runtimeConfig

### DIFF
--- a/src/runtime/nitro/server/middleware.ts
+++ b/src/runtime/nitro/server/middleware.ts
@@ -6,9 +6,12 @@ export default defineEventHandler(async (e) => {
   if (e.path === '/robots.txt' || e.path.startsWith('/__') || e.path.startsWith('/api') || e.path.startsWith('/_nuxt'))
     return
   const robotConfig = getPathRobotConfig(e)
-  const { header } = useRuntimeConfig(e)['nuxt-robots']
-  if (header) {
-    setHeader(e, 'X-Robots-Tag', robotConfig.rule)
+  const nuxtRobotsConfig = useRuntimeConfig(e)['nuxt-robots']
+  if (nuxtRobotsConfig) {
+    const { header } = nuxtRobotsConfig
+    if (header) {
+      setHeader(e, 'X-Robots-Tag', robotConfig.rule)
+    }
+    e.context.robots = robotConfig
   }
-  e.context.robots = robotConfig
 })


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/simplise/use-bootstrap/issues/52

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ x ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

An error started occurring when using the @nuxtjs/robots module. 

If the @nuxtjs/robots module is enabled and the nuxt-robots item is not present in the runtime, it will result in an error. 
I haven't confirmed the detailed behavior, but I modified the code to check for the existence of nuxt-robots.


![スクリーンショット 2024-10-27 161121](https://github.com/user-attachments/assets/901317ec-0e1f-4149-96d2-871ea09f992f)

