### PR TITLE
fix: nuxt content check at module setup

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -328,7 +328,7 @@ export default defineNuxtModule<ModuleOptions>({
     }
 
     const nitroPreset = resolveNitroPreset(nuxt.options.nitro)
-    let usingNuxtContent = hasNuxtModule('@nuxt/content') && config.disableNuxtContentIntegration !== false
+    let usingNuxtContent = hasNuxtModule('@nuxt/content') && config.disableNuxtContentIntegration !== true
     if (usingNuxtContent) {
       if (await hasNuxtModuleCompatibility('@nuxt/content', '^3')) {
         logger.warn('Nuxt Robots does not work with Nuxt Content v3 yet, the integration will be disabled. Learn more at: https://nuxtseo.com/docs/robots/guides/content')


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #169

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixed the initial state for `useNuxtContent` inside module's setup.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
