### PR TITLE
fix!: deprecate `disallowNonIndexableRoutes`

### DIFF
--- a/docs/content/3.api/1.config.md
+++ b/docs/content/3.api/1.config.md
@@ -80,12 +80,6 @@ The value to use when the page is indexable.
 
 The value to use when the page is not indexable.
 
-## `disallowNonIndexableRoutes: boolean`{lang="ts"}
-
-- Default: `'false'`{lang="ts"}
-
-Should route rules which disallow indexing be added to the `/robots.txt` file.
-
 ## `mergeWithRobotsTxtPath: boolean | string`{lang="ts"}
 
 - Default: `true`{lang="ts"}
@@ -167,3 +161,11 @@ export default defineNuxtConfig({
   }
 })
 ```
+
+## `disallowNonIndexableRoutes: boolean`{lang="ts"}
+
+**⚠️ Deprecated**: Explicitly disallow routes in the `/robots.txt` file if you don't want them to be accessible.
+
+- Default: `'false'`{lang="ts"}
+
+Should route rules which disallow indexing be added to the `/robots.txt` file.

--- a/src/module.ts
+++ b/src/module.ts
@@ -93,9 +93,11 @@ export interface ModuleOptions {
    */
   robotsDisabledValue: string
   /**
+   * @deprecated Explicitly add paths to your robots.txt with the `allow` and `disallow` options.
+   *
    * Should route rules which disallow indexing be added to the `/robots.txt` file.
    *
-   * @default true
+   * @default false
    */
   disallowNonIndexableRoutes: boolean
   /**
@@ -191,7 +193,7 @@ export default defineNuxtModule<ModuleOptions>({
     cacheControl: 'max-age=14400, must-revalidate',
     robotsEnabledValue: 'index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1',
     robotsDisabledValue: 'noindex, nofollow',
-    disallowNonIndexableRoutes: true,
+    disallowNonIndexableRoutes: false,
     robotsTxt: true,
   },
   async setup(config, nuxt) {

--- a/src/runtime/server/composables/getPathRobotConfig.ts
+++ b/src/runtime/server/composables/getPathRobotConfig.ts
@@ -82,7 +82,7 @@ export function getPathRobotConfig(e: H3Event, options?: { userAgent?: string, s
   // 3. nitro route rules
   nitroApp._robotsRuleMactcher = nitroApp._robotsRuleMactcher || createNitroRouteRuleMatcher()
   const routeRules = normaliseRobotsRouteRule(nitroApp._robotsRuleMactcher(path))
-  if (routeRules && (routeRules.allow || routeRules.rule)) {
+  if (routeRules && (typeof routeRules.allow !== 'undefined' || typeof routeRules.rule !== 'undefined')) {
     return {
       indexable: routeRules.allow,
       rule: routeRules.rule || (routeRules.allow ? robotsEnabledValue : robotsDisabledValue),

--- a/test/default.test.ts
+++ b/test/default.test.ts
@@ -24,8 +24,6 @@ describe('default', () => {
       Disallow: /users/*/hidden
       Disallow: /?a=
       Disallow: /visible?*a=
-      Disallow: /*/account
-      Disallow: /sub/*
 
       Sitemap: https://nuxtseo.com/sitemap.xml
       # END nuxt-robots"

--- a/test/groups.test.ts
+++ b/test/groups.test.ts
@@ -56,8 +56,6 @@ describe('stack', () => {
       Disallow: /users/*/hidden
       Disallow: /?a=
       Disallow: /visible?*a=
-      Disallow: /*/account
-      Disallow: /sub/*
 
       Sitemap: https://nuxtseo.com/sitemap.xml
       # END nuxt-robots"

--- a/test/mergeWithRobotsTxtPath.test.ts
+++ b/test/mergeWithRobotsTxtPath.test.ts
@@ -25,8 +25,6 @@ describe('mergeWithRobotsTxtPath', () => {
       Allow: /secret/exception
       Disallow: /secret
       Disallow: /admin
-      Disallow: /*/account
-      Disallow: /sub/*
 
       Sitemap: https://nuxtseo.com/sitemap.xml
       # END nuxt-robots"


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

The `disallowNonIndexableRoutes` config adds any ignored routes within your `routeRules` to `/robots.txt`. 

```ts
export default defineNuxtConfig({
  routeRules: {
    '/secret/**': { robots: false },
  }
})
```

```
# /robots.txt
Disallow: /secret/
```


This feature is inherently broken as robot meta tags (or  X-Robots-Header) and robots.txt are for different controls.
We can't automatically infer one from the other, for more context see [Controlling Web Crawlers](https://nuxtseo.com/learn/controlling-crawlers) but tldr; we may want robots to still visit a page but not index it.

This PR changes the default behavior to `false` for this config and sets it to deprecated. While this is marked as a breaking change, this should have no effect on your end SEO as the page will still be disabled from indexing

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
