### PR TITLE
feat: set `noindex` header for build asset dir `/_nuxt`

### DIFF
--- a/test/routeRules.test.ts
+++ b/test/routeRules.test.ts
@@ -55,6 +55,8 @@ describe('route rule merging', () => {
       Disallow: /robots-rule/*
       Disallow: /secret/*
       Disallow: /excluded/*
+      Disallow: /_nuxt
+      Disallow: /_nuxt/*
 
       Sitemap: https://nuxtseo.com/sitemap.xml
       # END nuxt-robots"


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Some users may find some of their assets within the asset build directory `/_nuxt` (or the directory itself) or getting indexed by Google.

For example just search google for `inurl:/_nuxt`

In almost all instances this is undesirable the only exception may be images that you'd like indexed but these should be included within your `/public` directory anyway.

This won't fix the indexing if users are using certain web servers which will automatically create directories for these files which is the case for some.

It's important to note that we DO NOT put this in robots.txt as it will cause issues with your pages being crawled and the module will now warn you if you do this.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
