### PR TITLE
fix: rule matcher typo

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -469,7 +469,7 @@ declare module 'nitropack' {
       ctx: import('${typesPath}').HookRobotsConfigContext
       nuxtContentUrls?: Set<string>
     },
-    _robotsRuleMactcher: (url: string) => string
+    _robotsRuleMatcher: (url: string) => string
   }
   interface NitroRouteRules {
     robots?: boolean | string | {

--- a/src/runtime/server/composables/getPathRobotConfig.ts
+++ b/src/runtime/server/composables/getPathRobotConfig.ts
@@ -85,7 +85,7 @@ export function getPathRobotConfig(e: H3Event, options?: { userAgent?: string, s
   }
 
   // 3. nitro route rules
-  nitroApp._robotsRuleMactcher = nitroApp._robotsRuleMactcher || createNitroRouteRuleMatcher(e)
+  nitroApp._robotsRuleMatcher = nitroApp._robotsRuleMatcher || createNitroRouteRuleMatcher(e)
   let routeRulesPath = path
   // if we're using i18n we need to strip leading prefixes so the rule will match
   if (runtimeConfig.public?.i18n?.locales) {
@@ -95,7 +95,7 @@ export function getPathRobotConfig(e: H3Event, options?: { userAgent?: string, s
       routeRulesPath = routeRulesPath.replace(`/${locale.code}`, '')
     }
   }
-  const routeRules = normaliseRobotsRouteRule(nitroApp._robotsRuleMactcher(routeRulesPath))
+  const routeRules = normaliseRobotsRouteRule(nitroApp._robotsRuleMatcher(routeRulesPath))
   if (routeRules && (typeof routeRules.allow !== 'undefined' || typeof routeRules.rule !== 'undefined')) {
     return {
       indexable: routeRules.allow,


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Noticed a typo while inspecting generated types, I'm assuming this is an internal property, if it isn't I can add a deprecation JSDoc and fallback to the previous property for backwards compat.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
