### PR TITLE
docs: nuxt config groups need to be inside of robots object 🤖

### DIFF
--- a/docs/content/2.guides/3.nuxt-config.md
+++ b/docs/content/2.guides/3.nuxt-config.md
@@ -42,15 +42,17 @@ When targeting specific robots, you can use the `groups` option to provide granu
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   // add more granular rules
-  groups: [
-    // block specific robots from specific pages
-    {
-      userAgent: ['AdsBot-Google-Mobile', 'AdsBot-Google-Mobile-Apps'],
-      disallow: ['/admin'],
-      allow: ['/admin/login'],
-      comments: 'Allow Google AdsBot to index the login page but no-admin pages'
-    },
-  ]
+  robots: {
+    groups: [
+      // block specific robots from specific pages
+      {
+        userAgent: ['AdsBot-Google-Mobile', 'AdsBot-Google-Mobile-Apps'],
+        disallow: ['/admin'],
+        allow: ['/admin/login'],
+        comments: 'Allow Google AdsBot to index the login page but no-admin pages'
+      },
+    ]
+  }
 })
 ```
 


### PR DESCRIPTION
### 🔗 Linked issue

Quick fix in the docs

### ❓ Type of change

- [ x ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I noticed that the robots wrapper is missing as I tried to copied the group config from the docs https://nuxtseo.com/docs/robots/guides/nuxt-config
