### PR TITLE
docs: fix typos and add robots.txt tool links

### DIFF
--- a/docs/content/1.getting-started/0.introduction.md
+++ b/docs/content/1.getting-started/0.introduction.md
@@ -44,7 +44,7 @@ Ensures pages that should not be indexed are not indexed with the following:
 
 Both enabled by default.
 
-- [How it works](/docs/robots/getting-started/how-it-works)
+- [How it works](/docs/robots/guides/how-it-works)
 
 ### 🕵️ Bot Detection
 
@@ -58,7 +58,7 @@ Identify search engines, social media crawlers, AI bots, automation tools, and s
 
 The module uses [Nuxt Site Config](/docs/site-config/getting-started/background) to determine if the site is in production mode.
 
-It will disables non-production environments from being indexed, avoiding duplicate content issues.
+It will disable non-production environments from being indexed, avoiding duplicate content issues.
 
 - [Environment Config](/docs/robots/guides/disable-indexing)
 
@@ -74,4 +74,8 @@ When you need even more control, use the runtime Nitro hooks to dynamically conf
 
 Will automatically fix any non-localised paths within your `allow` and `disallow` rules.
 
-- [I18n Integration](/docs/robots/integration/i18n)
+- [I18n Integration](/docs/robots/advanced/i18n)
+
+::callout{icon="i-heroicons-wrench" to="/tools/robots-txt-generator"}
+**Test your robots.txt** - Use our free [Robots.txt Generator & Tester](/tools/robots-txt-generator) to validate rules and test against 50+ user agents.
+::

--- a/docs/content/1.getting-started/3.troubleshooting.md
+++ b/docs/content/1.getting-started/3.troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 title: "Troubleshooting Nuxt Robots"
-description: Create minimal reproductions for Nuxt Robots or just experiment with the module.
+description: Debug Nuxt Robots issues using DevTools, config options, and minimal reproductions.
 navigation:
   title: "Troubleshooting"
 ---
@@ -18,6 +18,10 @@ This will show you the current robot rules and your robots.txt file.
 You can enable the [debug](/docs/robots/api/config#debug) option which will give you more granular output.
 
 This is enabled by default in development mode.
+
+## Debugging Tools
+
+- [Robots.txt Generator & Tester](/tools/robots-txt-generator) - Validate your robots.txt output and test against Googlebot, GPTBot, ClaudeBot and 50+ user agents
 
 ## Submitting an Issue
 

--- a/docs/content/2.guides/1.robots-txt.md
+++ b/docs/content/2.guides/1.robots-txt.md
@@ -84,6 +84,10 @@ Content-Signal: ai-train=no, search=yes
 See the [**AI Directives Guide**](/docs/robots/guides/ai-directives) for complete documentation, examples, validation rules, and best practices.
 ::
 
+::callout{icon="i-heroicons-check-circle" to="/tools/robots-txt-generator"}
+**Validate your output** - Test your robots.txt rules with our [Robots.txt Tester](/tools/robots-txt-generator).
+::
+
 ## Conflicting `public/robots.txt`
 
 To ensure other modules can integrate with your generated robots file, you must not have a `robots.txt` file in your `public` folder.

--- a/docs/content/2.guides/2.nuxt-config.md
+++ b/docs/content/2.guides/2.nuxt-config.md
@@ -8,8 +8,7 @@ If you need programmatic control, you can configure the module using nuxt.config
 ## Simple Configuration
 
 The simplest configuration is to provide an array of paths to disallow for the `*` user-agent. If needed you can
-provide `allow` pat
-You can simply add the path or path pattern to hs as well.
+provide `allow` paths as well.
 
 - `disallow` - An array of paths to disallow for the `*` user-agent.
 - `allow` - An array of paths to allow for the `*` user-agent.

--- a/docs/content/2.guides/5.ai-directives.md
+++ b/docs/content/2.guides/5.ai-directives.md
@@ -10,6 +10,10 @@ AI Directives allow you to express preferences about how AI systems, search engi
 
 Both can be used together in your robots.txt file and are enforced through the robots.txt protocol.
 
+::callout{icon="i-heroicons-cpu-chip" to="/tools/robots-txt-generator"}
+**Test AI crawler blocking** - Our [Robots.txt Generator](/tools/robots-txt-generator) includes presets for GPTBot, ClaudeBot, and other AI crawlers.
+::
+
 ::alert{type="warning"}
 **Important:** AI directives rely on voluntary compliance by crawlers and AI systems. They are not enforced by web servers and should be combined with other protection methods for sensitive content.
 ::


### PR DESCRIPTION
## Summary
- Fix garbled text in nuxt-config.md
- Fix "disables" typo in introduction.md
- Fix broken internal links (how-it-works, i18n paths)
- Add Robots.txt Generator callouts to intro, troubleshooting, robots-txt, and ai-directives pages

## Test plan
- [ ] Verify links resolve correctly
- [ ] Check callout renders properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)