### PR TITLE
docs: fix internal links to use correct paths

### DIFF
--- a/docs/content/1.getting-started/0.introduction.md
+++ b/docs/content/1.getting-started/0.introduction.md
@@ -13,7 +13,7 @@ The core feature of the module is:
 - Telling [crawlers](https://developers.google.com/search/docs/crawling-indexing/overview-google-crawlers) which paths they can and cannot access using a [robots.txt](https://developers.google.com/search/docs/crawling-indexing/robots/intro) file.
 - Telling [search engine crawlers](https://developers.google.com/search/docs/crawling-indexing/googlebot) what they can show in search results from your site using a `<meta name="robots" content="index">`{lang="html"} `X-Robots-Tag` HTTP header.
 
-New to robots or SEO? Check out the [Controlling Web Crawlers](/learn/controlling-crawlers) guide to learn more about why you might
+New to robots or SEO? Check out the [Controlling Web Crawlers](/learn-seo/nuxt/controlling-crawlers) guide to learn more about why you might
 need these features.
 
 :LearnLabel{label="Conquering Web Crawlers" to="/learn/controlling-crawlers" icon="i-ph-robot-duotone"}

--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -43,7 +43,7 @@ while this works out-of-the-box for most providers, it's good to verify this is 
 - [Disable Page Indexing](/docs/robots/guides/disable-page-indexing) - You should consider excluding pages that are not useful to search engines, for example
 any routes which require authentication should be ignored.
 
-Make sure you understand the differences between robots.txt vs robots meta tag with the [Controlling Web Crawlers](/learn/controlling-crawlers) guide.
+Make sure you understand the differences between robots.txt vs robots meta tag with the [Controlling Web Crawlers](/learn-seo/nuxt/controlling-crawlers) guide.
 
 :LearnLabel{label="Controlling Web Crawlers" to="/learn/controlling-crawlers" icon="i-ph-robot-duotone"}
 

--- a/docs/content/2.guides/1.robot-recipes.md
+++ b/docs/content/2.guides/1.robot-recipes.md
@@ -7,7 +7,7 @@ description: 'Common robots.txt patterns including blocking bad bots, AI crawler
 
 As a minimum the only recommended configuration for robots is to [disable indexing for non-production environments](/docs/robots/guides/disable-indexing).
 
-Many sites will never need to configure their [`robots.txt`](https://nuxtseo.com/learn/controlling-crawlers/robots-txt) or [`robots` meta tag](https://nuxtseo.com/learn/controlling-crawlers/meta-tags) beyond this, as the [controlling web crawlers](/learn/controlling-crawlers)
+Many sites will never need to configure their [`robots.txt`](https://nuxtseo.com/learn/controlling-crawlers/robots-txt) or [`robots` meta tag](https://nuxtseo.com/learn/controlling-crawlers/meta-tags) beyond this, as the [controlling web crawlers](/learn-seo/nuxt/controlling-crawlers)
 is an advanced use case and topic.
 
 However, if you're looking to get the best SEO and performance results, you may consider some of the recipes on this page for
@@ -58,7 +58,7 @@ See [Config using Robots.txt](/docs/robots/guides/robots-txt) for more informati
 
 ### Whitelisting Open Graph Tags
 
-If you have certain pages that you don't want indexed but you still want their [Open Graph Tags](/learn/mastering-meta/open-graph) to be crawled, you can target the specific
+If you have certain pages that you don't want indexed but you still want their [Open Graph Tags](/learn-seo/nuxt/mastering-meta/social-sharing) to be crawled, you can target the specific
 user-agents.
 
 ```robots-txt [public/_robots.txt]

--- a/docs/content/2.guides/1.robots-txt.md
+++ b/docs/content/2.guides/1.robots-txt.md
@@ -8,7 +8,7 @@ description: Configure your generated robots.txt file with a robots.txt file.
 The [robots.txt standard](https://developers.google.com/search/docs/crawling-indexing/robots/create-robots-txt) is important for search engines
 to understand which pages to crawl and index on your site.
 
-New to robots.txt? Check out the [Robots.txt Guide](/learn/controlling-crawlers/robots-txt) to learn more.
+New to robots.txt? Check out the [Robots.txt Guide](/learn-seo/nuxt/controlling-crawlers/robots-txt) to learn more.
 
 To match closer to the robots standard, Nuxt Robots recommends configuring the module by using a `robots.txt`, which will be parsed, validated, configuring the module.
 

--- a/docs/content/3.advanced/3.content.md
+++ b/docs/content/3.advanced/3.content.md
@@ -69,7 +69,7 @@ path: /foo
 ## Usage
 
 You can use any boolean or string value as `robots` that will be forwarded as a
-[Meta Robots Tag](/learn/controlling-crawlers/meta-tags).
+[Meta Robots Tag](/learn-seo/nuxt/controlling-crawlers/meta-tags).
 
 ::code-group
 


### PR DESCRIPTION
## Summary
- Update `/learn/` links to `/learn-seo/nuxt/`
- Fix `controlling-crawlers` and `mastering-meta` paths

These links were causing unnecessary redirects on nuxtseo.com.

🤖 Generated with [Claude Code](https://claude.ai/code)