### PR TITLE
fix(types): broken nuxt v4 check

### DIFF
--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,6 +1,6 @@
 import type { Nuxt } from '@nuxt/schema'
 import type { ModuleOptions } from './module'
-import { addTypeTemplate } from '@nuxt/kit'
+import { addTypeTemplate, isNuxtMajorVersion } from '@nuxt/kit'
 
 interface TemplateContext {
   nuxt: Nuxt
@@ -8,12 +8,13 @@ interface TemplateContext {
 }
 
 export function registerTypeTemplates({ nuxt }: TemplateContext) {
-  // Nuxt 4 augments both 'nitropack' and 'nitropack/types' (matching @nuxt/nitro-server).
-  // Augmenting only one leaves the other's re-exported NitroRouteConfig/NitroRouteRules
-  // without our `robots` key, which breaks consumers like @nuxt/kit's extendRouteRules
-  // that pull the type through both module paths.
-  const isNuxt4 = Number(nuxt.options.future?.compatibilityVersion) === 4
-  const nitroModules = isNuxt4 ? ['nitropack', 'nitropack/types'] : ['nitropack']
+  // Nuxt 4 ships Nitro v3, which exposes `nitropack/types` as a public subpath.
+  // @nuxt/kit's extendRouteRules unions NitroRouteConfig across both 'nitropack'
+  // and 'nitropack/types', so augmenting only one leaves the other's re-exported
+  // interface without our `robots` key.
+  const nitroModules = isNuxtMajorVersion(4, nuxt)
+    ? ['nitropack', 'nitropack/types']
+    : ['nitropack']
 
   // Nuxt-only type augmentations (PageMeta)
   addTypeTemplate({

--- a/test/types/templates.test-d.ts
+++ b/test/types/templates.test-d.ts
@@ -7,6 +7,7 @@ import type {
 import type { H3EventContext } from 'h3'
 import type { NitroRouteConfig as NitroRouteConfigPack, NitroRouteRules as NitroRouteRulesPack } from 'nitropack'
 import type { NitroRouteConfig, NitroRouteRules, NitroRuntimeHooks } from 'nitropack/types'
+import type { NuxtConfig } from 'nuxt/schema'
 import type { PageMeta } from '#app'
 import { extendRouteRules } from '@nuxt/kit'
 import { describe, expectTypeOf, it } from 'vitest'
@@ -62,6 +63,19 @@ describe('nitropack augmentations (cross-module-path)', () => {
     }))
     expectTypeOf<NitroRouteConfig>().toExtend<{ ssr?: boolean, robots?: RobotsValue | { indexable: boolean, rule: string } }>()
     expectTypeOf<NitroRouteConfigPack>().toExtend<{ ssr?: boolean, robots?: RobotsValue | { indexable: boolean, rule: string } }>()
+  })
+})
+
+// Regression test for https://github.com/nuxt-modules/robots/issues/299
+// `nuxt.config.ts` routeRules are typed via `NuxtConfig['routeRules']`,
+// which (in Nuxt 4) resolves NitroRouteConfig through 'nitropack/types'.
+// If only 'nitropack' is augmented, declaring `robots` in routeRules fails
+// with TS2353 "Object literal may only specify known properties".
+describe('NuxtConfig routeRules (issue #299)', () => {
+  it('NuxtConfig.routeRules accepts a robots-tagged literal', () => {
+    expectTypeOf<{ '/admin': { robots: false } }>().toExtend<NonNullable<NuxtConfig['routeRules']>>()
+    expectTypeOf<{ '/private': { robots: 'noindex, nofollow' } }>().toExtend<NonNullable<NuxtConfig['routeRules']>>()
+    expectTypeOf<{ '/legacy': { robots: { indexable: false, rule: 'noindex' } } }>().toExtend<NonNullable<NuxtConfig['routeRules']>>()
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #299

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The `nitropack/types` augmentation added in #295 was gated on `nuxt.options.future.compatibilityVersion === 4`, which is unset on most Nuxt 4 projects. The check therefore silently skipped the second augmentation, leaving `routeRules.robots` failing typecheck with TS2353 on Nuxt 4.

Switched the gate to `@nuxt/kit`'s `isNuxtMajorVersion(4, nuxt)`, which reads the actual installed Nuxt version. Existing cross-module-path regression tests in `test/types/templates.test-d.ts` cover the fix.