### PR TITLE
chore(devtools): drop redundant @iconify-json/carbon devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "@antfu/eslint-config": "catalog:",
     "@arethetypeswrong/cli": "catalog:dev",
     "@headlessui/vue": "catalog:dev",
-    "@iconify-json/carbon": "catalog:dev",
     "@iconify-json/logos": "catalog:dev",
     "@iconify-json/ri": "catalog:dev",
     "@iconify-json/tabler": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,9 +124,6 @@ catalogs:
     '@headlessui/vue':
       specifier: ^1.7.23
       version: 1.7.23
-    '@iconify-json/carbon':
-      specifier: ^1.2.23
-      version: 1.2.23
     '@iconify-json/logos':
       specifier: ^1.2.11
       version: 1.2.11
@@ -205,9 +202,6 @@ importers:
       '@headlessui/vue':
         specifier: catalog:dev
         version: 1.7.23(vue@3.5.35(typescript@6.0.3))
-      '@iconify-json/carbon':
-        specifier: catalog:dev
-        version: 1.2.23
       '@iconify-json/logos':
         specifier: catalog:dev
         version: 1.2.11


### PR DESCRIPTION
### 📚 Description

`nuxtseo-layer-devtools` (a devDependency) already provides `@iconify-json/carbon` for the assembled DevTools client, and robots doesn't import it anywhere outside `devtools/`. Dropping the redundant declaration keeps the carbon icon set versioned in one place (the layer) and avoids cross-repo catalog drift.

devDep-only, so no effect on what ships to consumers. Companion to harlan-zw/nuxt-seo#578.