### PR TITLE
fix: register robots Nitro types for node context

### DIFF
--- a/src/templates.ts
+++ b/src/templates.ts
@@ -80,6 +80,7 @@ export {}
 `,
   }, {
     nitro: true,
+    node: true,
     nuxt: true,
   })
 }

--- a/test/unit/templates.test.ts
+++ b/test/unit/templates.test.ts
@@ -1,0 +1,29 @@
+import { addTypeTemplate } from '@nuxt/kit'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { registerTypeTemplates } from '../../src/templates'
+
+vi.mock('@nuxt/kit', () => ({
+  addTypeTemplate: vi.fn(),
+  isNuxtMajorVersion: vi.fn(() => true),
+}))
+
+describe('registerTypeTemplates', () => {
+  beforeEach(() => {
+    vi.mocked(addTypeTemplate).mockClear()
+  })
+
+  it('registers Nitro augmentations in the Nuxt node type context', () => {
+    registerTypeTemplates({ nuxt: {} as any, config: {} as any })
+
+    expect(addTypeTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filename: 'types/nuxt-robots-nitro.d.ts',
+      }),
+      {
+        nitro: true,
+        node: true,
+        nuxt: true,
+      },
+    )
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #304

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Nuxt 4 reads `routeRules` types for `nuxt.config.ts` through the node type context. `nuxt-robots-nitro.d.ts` was only emitted for Nuxt and Nitro, so `routeRules.robots` still failed TS2353 in config files.

Register the Nitro type template with `node: true` and add a unit regression for that template option.