### PR TITLE
fix: sync AI crawler user agents

### DIFF
--- a/docs/content/2.guides/7.robot-recipes.md
+++ b/docs/content/2.guides/7.robot-recipes.md
@@ -49,9 +49,7 @@ export default defineNuxtConfig({
 })
 ```
 
-This will block the AI crawlers listed in the `AiBots` constant, which follows the [ai.robots.txt](https://github.com/ai-robots-txt/ai.robots.txt) reference list: `GPTBot`, `ChatGPT-User`, `OAI-SearchBot`, `ClaudeBot`, `Claude-User`, `Claude-SearchBot`, `Claude-Web`, `anthropic-ai`, `Google-Extended`, `Google-CloudVertexBot`, `Google-NotebookLM`, `Gemini-Deep-Research`, `GoogleOther`, `meta-externalagent`, `meta-externalfetcher`, `FacebookBot`, `Amazonbot`, `bedrockbot`, `Applebot-Extended`, `PerplexityBot`, `Perplexity-User`, `Bytespider`, `TikTokSpider`, `omgili`, `omgilibot`, `Webzio-Extended`, `YandexAdditional`, `YandexAdditionalBot`, `CCBot`, `cohere-ai`, `Diffbot`, `ImagesiftBot`, `MistralAI-User`, `DeepSeekBot`, `AI2Bot`, `Ai2Bot-Dolma`, `YouBot`, `Timpibot`, `PanguBot`, `DuckAssistBot`, `FirecrawlAgent`, `ICC-Crawler`, `Kangaroo Bot`, `SemrushBot-OCOB`, `img2dataset`
-
-Search crawlers are not affected. `Googlebot`, `Applebot` (Siri and Spotlight) and `facebookexternalhit` (Open Graph link previews) are deliberately left out, so blocking AI bots never costs you search visibility or social previews.
+This adds a disallow rule for the training, AI search, and user-directed retrieval agents listed in the [`AiBots` constant](https://github.com/nuxt-modules/robots/blob/main/src/const.ts). Blocking search and retrieval agents can reduce your site's visibility and citations in AI-generated answers. Robots.txt is voluntary, and some user-triggered agents may ignore its rules.
 
 ### Blocking Privileged Pages
 

--- a/docs/content/2.guides/7.robot-recipes.md
+++ b/docs/content/2.guides/7.robot-recipes.md
@@ -49,7 +49,9 @@ export default defineNuxtConfig({
 })
 ```
 
-This will block the following AI crawlers: `GPTBot`, `ChatGPT-User`, `Claude-Web`, `anthropic-ai`, `Applebot-Extended`, `Bytespider`, `CCBot`, `cohere-ai`, `Diffbot`, `FacebookBot`, `Google-Extended`, `ImagesiftBot`, `PerplexityBot`, `OmigiliBot`, `Omigili`
+This will block the AI crawlers listed in the `AiBots` constant, which follows the [ai.robots.txt](https://github.com/ai-robots-txt/ai.robots.txt) reference list: `GPTBot`, `ChatGPT-User`, `OAI-SearchBot`, `ClaudeBot`, `Claude-User`, `Claude-SearchBot`, `Claude-Web`, `anthropic-ai`, `Google-Extended`, `Google-CloudVertexBot`, `Google-NotebookLM`, `Gemini-Deep-Research`, `GoogleOther`, `meta-externalagent`, `meta-externalfetcher`, `FacebookBot`, `Amazonbot`, `bedrockbot`, `Applebot-Extended`, `PerplexityBot`, `Perplexity-User`, `Bytespider`, `TikTokSpider`, `omgili`, `omgilibot`, `Webzio-Extended`, `YandexAdditional`, `YandexAdditionalBot`, `CCBot`, `cohere-ai`, `Diffbot`, `ImagesiftBot`, `MistralAI-User`, `DeepSeekBot`, `AI2Bot`, `Ai2Bot-Dolma`, `YouBot`, `Timpibot`, `PanguBot`, `DuckAssistBot`, `FirecrawlAgent`, `ICC-Crawler`, `Kangaroo Bot`, `SemrushBot-OCOB`, `img2dataset`
+
+Search crawlers are not affected. `Googlebot`, `Applebot` (Siri and Spotlight) and `facebookexternalhit` (Open Graph link previews) are deliberately left out, so blocking AI bots never costs you search visibility or social previews.
 
 ### Blocking Privileged Pages
 

--- a/docs/content/4.api/1.config.md
+++ b/docs/content/4.api/1.config.md
@@ -140,7 +140,7 @@ export default defineNuxtConfig({
 
 - Default: `false`{lang="ts"}
 
-Blocks AI crawlers from crawling your site. This adds a rule group disallowing `/` for known AI bots defined in the `AiBots` constant.
+Adds a rule group that disallows `/` for the training, AI search, and user-directed retrieval agents defined in the [`AiBots` constant](https://github.com/nuxt-modules/robots/blob/main/src/const.ts). Blocking search and retrieval agents can reduce your site's visibility and citations in AI-generated answers. Some user-triggered agents may ignore robots.txt rules.
 
 ```ts twoslash
 export default defineNuxtConfig({

--- a/src/const.ts
+++ b/src/const.ts
@@ -19,20 +19,71 @@ export const NonHelpfulBots = [
   'magpie-crawler',
 ]
 
+/**
+ * A list of AI crawler user agents, both training and retrieval.
+ *
+ * Search crawlers are deliberately excluded, so `blockAiBots` never costs a site its search
+ * visibility. This is why `Googlebot`, `Applebot` (Siri, Spotlight) and `facebookexternalhit`
+ * (Open Graph previews) are absent, while their AI-only counterparts `Google-Extended` and
+ * `Applebot-Extended` are listed.
+ *
+ * @credits https://github.com/ai-robots-txt/ai.robots.txt
+ */
 export const AiBots = [
+  // OpenAI
   'GPTBot',
   'ChatGPT-User',
+  'OAI-SearchBot',
+  // Anthropic
+  'ClaudeBot',
+  'Claude-User',
+  'Claude-SearchBot',
   'Claude-Web',
   'anthropic-ai',
+  // Google
+  'Google-Extended',
+  'Google-CloudVertexBot',
+  'Google-NotebookLM',
+  'Gemini-Deep-Research',
+  'GoogleOther',
+  // Meta
+  'meta-externalagent',
+  'meta-externalfetcher',
+  'FacebookBot',
+  // Amazon
+  'Amazonbot',
+  'bedrockbot',
+  // Apple
   'Applebot-Extended',
+  // Perplexity
+  'PerplexityBot',
+  'Perplexity-User',
+  // ByteDance
   'Bytespider',
+  'TikTokSpider',
+  // Webz.io
+  'omgili',
+  'omgilibot',
+  'Webzio-Extended',
+  // Yandex
+  'YandexAdditional',
+  'YandexAdditionalBot',
+  // Others
   'CCBot',
   'cohere-ai',
   'Diffbot',
-  'FacebookBot',
-  'Google-Extended',
   'ImagesiftBot',
-  'PerplexityBot',
-  'OmigiliBot',
-  'Omigili',
+  'MistralAI-User',
+  'DeepSeekBot',
+  'AI2Bot',
+  'Ai2Bot-Dolma',
+  'YouBot',
+  'Timpibot',
+  'PanguBot',
+  'DuckAssistBot',
+  'FirecrawlAgent',
+  'ICC-Crawler',
+  'Kangaroo Bot',
+  'SemrushBot-OCOB',
+  'img2dataset',
 ]

--- a/src/const.ts
+++ b/src/const.ts
@@ -20,38 +20,38 @@ export const NonHelpfulBots = [
 ]
 
 /**
- * A list of AI crawler user agents, both training and retrieval.
+ * AI-related robots.txt product tokens for training, search, and user-directed retrieval.
  *
- * Search crawlers are deliberately excluded, so `blockAiBots` never costs a site its search
- * visibility. This is why `Googlebot`, `Applebot` (Siri, Spotlight) and `facebookexternalhit`
- * (Open Graph previews) are absent, while their AI-only counterparts `Google-Extended` and
- * `Applebot-Extended` are listed.
+ * Blocking search and retrieval bots can reduce a site's visibility in AI-generated answers.
+ * Robots.txt is also voluntary, and some user-triggered fetchers may ignore these directives.
  *
- * @credits https://github.com/ai-robots-txt/ai.robots.txt
+ * @see https://github.com/ai-robots-txt/ai.robots.txt
  */
 export const AiBots = [
   // OpenAI
   'GPTBot',
-  'ChatGPT-User',
   'OAI-SearchBot',
+  'ChatGPT-User',
   // Anthropic
   'ClaudeBot',
-  'Claude-User',
   'Claude-SearchBot',
+  'Claude-User',
   'Claude-Web',
   'anthropic-ai',
   // Google
   'Google-Extended',
   'Google-CloudVertexBot',
+  'Google-GeminiNotebook',
   'Google-NotebookLM',
-  'Gemini-Deep-Research',
-  'GoogleOther',
+  'Google-Agent',
   // Meta
   'meta-externalagent',
   'meta-externalfetcher',
   'FacebookBot',
   // Amazon
   'Amazonbot',
+  'Amzn-SearchBot',
+  'Amzn-User',
   'bedrockbot',
   // Apple
   'Applebot-Extended',
@@ -60,7 +60,6 @@ export const AiBots = [
   'Perplexity-User',
   // ByteDance
   'Bytespider',
-  'TikTokSpider',
   // Webz.io
   'omgili',
   'omgilibot',
@@ -74,16 +73,10 @@ export const AiBots = [
   'Diffbot',
   'ImagesiftBot',
   'MistralAI-User',
-  'DeepSeekBot',
+  'MistralAI-Index',
   'AI2Bot',
-  'Ai2Bot-Dolma',
-  'YouBot',
-  'Timpibot',
-  'PanguBot',
   'DuckAssistBot',
   'FirecrawlAgent',
   'ICC-Crawler',
-  'Kangaroo Bot',
   'SemrushBot-OCOB',
-  'img2dataset',
 ]

--- a/test/unit/const.test.ts
+++ b/test/unit/const.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { AiBots } from '../../src/const'
+
+describe('aiBots', () => {
+  it('contains unique user-agent tokens', () => {
+    const normalisedBots = AiBots.map(bot => bot.toLowerCase())
+
+    expect(new Set(normalisedBots).size).toBe(AiBots.length)
+  })
+
+  it('uses current documented crawler tokens', () => {
+    expect(AiBots).toEqual(expect.arrayContaining([
+      'Amzn-SearchBot',
+      'Google-GeminiNotebook',
+      'MistralAI-Index',
+      'omgili',
+      'omgilibot',
+    ]))
+    expect(AiBots).not.toContain('Omigili')
+    expect(AiBots).not.toContain('OmigiliBot')
+    expect(AiBots).not.toContain('GoogleOther')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

None. Found while auditing the generated `robots.txt` of a downstream project.

### ❓ Type of change

- [x] 🐞 Bug fix
- [x] 📖 Documentation

### 📚 Description

Updates `AiBots` with current, documented product tokens from OpenAI, Anthropic, Google, Meta, Amazon, Mistral, and other crawler operators. It also fixes the misspelled Webz.io tokens, `Omigili` and `OmigiliBot`.

The list leaves out `GoogleOther`, which Google documents as a generic crawler, plus entries supported only by third-party directories. The docs now state that blocking AI search and retrieval agents can reduce visibility in generated answers, and that some user-triggered agents may ignore robots.txt.

Adds unit coverage for duplicate tokens, current names, and the corrected Webz.io spellings.

### 📝 Checklist

- [ ] I have linked an issue or discussion
- [x] I have updated the documentation accordingly