### PR TITLE
fix: match user-agent groups against the request's product string

### DIFF
--- a/src/runtime/server/composables/getPathRobotConfig.ts
+++ b/src/runtime/server/composables/getPathRobotConfig.ts
@@ -44,7 +44,11 @@ export function getPathRobotConfig(e: H3Event, options?: { userAgent?: string, s
     // run explicit user agent matching first
     ...nitroApp._robots.ctx.groups.filter((g) => {
       if (userAgent) {
-        return g.userAgent.some(ua => ua.toLowerCase().includes(userAgent.toLowerCase()))
+        // The group's product token has to be found in the user agent, not the other way around:
+        // crawlers send a product string (`Mozilla/5.0 (compatible; Googlebot/2.1; ...)`), which
+        // can never be a substring of `Googlebot`. Equality still matches, so a bare token passed
+        // through `options.userAgent` keeps working.
+        return g.userAgent.some(ua => !!ua && userAgent.toLowerCase().includes(ua.toLowerCase()))
       }
       return false
     }),

--- a/test/e2e/groups.test.ts
+++ b/test/e2e/groups.test.ts
@@ -69,4 +69,22 @@ describe('stack', async () => {
     })
     expect(headers.get('x-robots-tag')).toMatchInlineSnapshot(`"noindex, nofollow"`)
   })
+  it('blocks the real GoogleBot product string from /test3', async () => {
+    // Crawlers send a product string, never the bare token above — the group has to match a user
+    // agent that CONTAINS `Googlebot`.
+    const { headers } = await $fetch.raw('/test3', {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+      },
+    })
+    expect(headers.get('x-robots-tag')).toMatchInlineSnapshot(`"noindex, nofollow"`)
+  })
+  it('does not apply the GoogleBot group to a browser', async () => {
+    const { headers } = await $fetch.raw('/test3', {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15',
+      },
+    })
+    expect(headers.get('x-robots-tag')).not.toContain('noindex')
+  })
 })

--- a/test/e2e/hook-config.test.ts
+++ b/test/e2e/hook-config.test.ts
@@ -71,6 +71,17 @@ describe('robots:config hook - issue #233', async () => {
     expect(indexHeaders.get('x-robots-tag')).toMatchInlineSnapshot(`"noindex, nofollow"`)
   })
 
+  it('should block the real AhrefsBot product string from all paths', async () => {
+    // The bare token above is not what Ahrefs sends; this is.
+    const { headers: indexHeaders } = await $fetch.raw('/', {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)',
+      },
+    })
+
+    expect(indexHeaders.get('x-robots-tag')).toMatchInlineSnapshot(`"noindex, nofollow"`)
+  })
+
   // Edge case: Multiple hook calls shouldn't cause issues
   it('should handle multiple hook calls without breaking normalization', async () => {
     // Second request - the hook might be called again depending on caching


### PR DESCRIPTION
### 🔗 Linked issue

resolves #314

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`getPathRobotConfig()` selected a group by asking whether the **group token contained the request's User-Agent**. Robots.txt matching is the other way round, and since crawlers advertise a product string — `Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)` — that string can never be a substring of the token `Googlebot`. So a `User-agent: Googlebot` group never applied to Googlebot, while any short string that happened to sit inside a token (`Apple`, `bot`, even `e` for an `Applebot-Extended` group) inherited that group's rules.

Only the per-request decision was affected: the `X-Robots-Tag` header and the SSR `<meta name="robots">`. The generated `/robots.txt` was always correct.

The fix flips the containment. **String equality still matches**, so a caller passing a bare token through `options.userAgent` — the form the API docs describe — behaves exactly as before, and the two existing assertions that send `'User-Agent': 'Googlebot'` / `'AhrefsBot'` stay green. The only matches that disappear are the accidental ones: a request with UA `Googlebot` no longer picks up a `Googlebot-Image` group. Empty tokens are guarded, since `''` is a substring of everything.

Three tests are added next to the existing ones — two of them fail before this change, the third is a control that must keep passing either way:

- `test/e2e/groups.test.ts` — the fixture's `User-agent: Googlebot` / `Disallow: /test3` group, asserted with Google's real product string (fails before), plus a browser that must **not** pick up that group (passes before and after).
- `test/e2e/hook-config.test.ts` — the same for the hook-provided `AhrefsBot` group, using the real Ahrefs product string already used verbatim in `test/unit/bot-detection.test.ts` (fails before).

The existing tests could not catch this: they send the bare token, and with two equal strings containment holds in either direction.
