### PR TITLE
fix(botDetection): stop duplicate server auto-imports when disabled

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -619,9 +619,11 @@ export default defineNuxtModule<ModuleOptions>({
 
     addServerImportsDir(resolve('./runtime/server/composables'))
 
-    // Conditionally provide bot detection server composables
+    // The bot detection helpers must only come from one source: the real
+    // implementations above, or the mocks below. Exclude the real file from
+    // the scan when disabled so the auto-import registry holds no duplicates.
     if (!config.botDetection) {
-      // Override bot detection imports with mock implementations when disabled
+      addServerImportsDir(`!${resolve('./runtime/server/composables/getBotDetection.ts')}`)
       addServerImports([
         'getBotDetection',
         'isBot',

--- a/test/e2e/bot-detection-disabled.test.ts
+++ b/test/e2e/bot-detection-disabled.test.ts
@@ -1,0 +1,24 @@
+import { createResolver } from '@nuxt/kit'
+import { $fetch, setup } from '@nuxt/test-utils'
+import { describe, expect, it } from 'vitest'
+
+const { resolve } = createResolver(import.meta.url)
+
+process.env.NODE_ENV = 'production'
+
+await setup({
+  rootDir: resolve('../fixtures/bot-detection-disabled'),
+  build: true,
+})
+
+describe('bot detection disabled', () => {
+  it('builds with the mock auto-imports and reports no bot for a bot user agent', async () => {
+    const result = await $fetch('/api/bot-detection', {
+      headers: {
+        'user-agent': 'Googlebot/2.1 (+http://www.google.com/bot.html)',
+      },
+    }) as any
+
+    expect(result.isBot).toBe(false)
+  }, 15_000)
+})

--- a/test/fixtures/bot-detection-disabled/nuxt.config.ts
+++ b/test/fixtures/bot-detection-disabled/nuxt.config.ts
@@ -1,0 +1,18 @@
+import NuxtRobots from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [
+    NuxtRobots,
+  ],
+  robots: {
+    botDetection: false,
+  },
+  // this repo's .nuxtrc disables nitro auto-imports; opt back in so the server
+  // route exercises the module's auto-import registrations like a user app would
+  imports: {
+    autoImport: true,
+  },
+  site: {
+    url: 'https://nuxtseo.com',
+  },
+})

--- a/test/fixtures/bot-detection-disabled/pages/index.vue
+++ b/test/fixtures/bot-detection-disabled/pages/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <h1>Bot Detection Disabled Test</h1>
+  </div>
+</template>

--- a/test/fixtures/bot-detection-disabled/server/api/bot-detection.ts
+++ b/test/fixtures/bot-detection-disabled/server/api/bot-detection.ts
@@ -1,0 +1,9 @@
+// `isBot` is resolved by the Nitro auto-import registry: with `botDetection: false`
+// it must come from the module's mock-composables and always report false.
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler(e => {
+  return {
+    isBot: isBot(e),
+  }
+})

--- a/test/fixtures/bot-detection-disabled/tsconfig.json
+++ b/test/fixtures/bot-detection-disabled/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}

--- a/test/unit/bot-detection-server-imports.test.ts
+++ b/test/unit/bot-detection-server-imports.test.ts
@@ -1,0 +1,128 @@
+import { createRequire } from 'node:module'
+import { addServerImports, addServerImportsDir } from '@nuxt/kit'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@nuxt/kit', async () => {
+  const path = await import('node:path')
+  return {
+    addImports: vi.fn(),
+    addPlugin: vi.fn(),
+    addPrerenderRoutes: vi.fn(),
+    addServerHandler: vi.fn(),
+    addServerImports: vi.fn(),
+    addServerImportsDir: vi.fn(),
+    addServerPlugin: vi.fn(),
+    createResolver: () => ({
+      resolve: (...args: string[]) => path.resolve(process.cwd(), 'src', ...args),
+    }),
+    defineNuxtModule: (options: unknown) => options,
+    extendRouteRules: vi.fn(),
+    hasNuxtModule: vi.fn(() => false),
+    addTypeTemplate: vi.fn(),
+  }
+})
+
+vi.mock('nuxt-site-config/kit', () => ({
+  installNuxtSiteConfig: vi.fn(),
+  updateSiteConfig: vi.fn(),
+}))
+
+vi.mock('nuxtseo-shared/kit', () => ({
+  setupNitroRuntimeCompatibility: vi.fn(() => ({ _tag: 'nitro-v2' })),
+  useModuleLogger: vi.fn(() => Object.fromEntries(['debug', 'error', 'warn', 'info', 'log'].map(k => [k, vi.fn()]))),
+  isNuxtGenerate: vi.fn(() => false),
+  resolveContentProvider: vi.fn(async () => ({ _tag: 'None' })),
+  resolveNitroPreset: vi.fn(() => 'node-server'),
+  renderNitroTypeAugmentations: vi.fn(() => ''),
+}))
+
+vi.mock('pkg-types', () => ({
+  readPackageJSON: vi.fn(async () => ({ version: '0.0.0' })),
+}))
+
+// unimport is what Nitro uses to expand scanned auto-import dirs; it ships with nuxt
+const { scanDirExports } = createRequire(createRequire(import.meta.url).resolve('nuxt/package.json'))('unimport') as {
+  scanDirExports: (dirs: string[]) => Promise<{ name?: string, as?: string, from: string }[]>
+}
+
+const BOT_DETECTION_HELPERS = ['getBotDetection', 'isBot', 'getBotInfo']
+
+function fakeNuxt() {
+  return {
+    options: {
+      dev: false,
+      rootDir: process.cwd(),
+      app: { baseURL: '', buildAssetsDir: '/_nuxt/' },
+      dir: { public: 'public', assets: 'assets', pages: 'pages' },
+      experimental: { extraPageMetaExtractionKeys: [] },
+      runtimeConfig: { public: {} },
+      nitro: { alias: {} },
+      alias: {},
+      routeRules: {},
+    },
+    hook: vi.fn(),
+    hooks: { hook: vi.fn(), callHook: vi.fn() },
+  } as any
+}
+
+async function collectServerImportRegistrations(botDetection: boolean) {
+  vi.clearAllMocks()
+  const { default: module } = await import('../../src/module')
+  await module.setup({
+    enabled: true,
+    botDetection,
+    autoI18n: false,
+    robotsTxt: false,
+    metaTag: false,
+    header: false,
+    debug: false,
+    mergeWithRobotsTxtPath: false,
+    blockAiBots: false,
+    blockNonSeoBots: false,
+  } as any, fakeNuxt())
+
+  const dirs = vi.mocked(addServerImportsDir).mock.calls.flatMap(args => args[0])
+  const explicit = vi.mocked(addServerImports).mock.calls.flatMap(args => args[0])
+  const scanned = await scanDirExports(dirs)
+  // only registrations owned by this module's server runtime
+  return [...scanned, ...explicit]
+    .map(i => ({ name: (i.as || i.name)!, from: i.from.replace(/\\/g, '/') }))
+    .filter(i => i.from.includes('/src/runtime/server/'))
+}
+
+describe('server auto-import registration', () => {
+  it('registers each bot detection helper exactly once from the mocks when botDetection is false', async () => {
+    const registrations = await collectServerImportRegistrations(false)
+    const botRegistrations = registrations.filter(i => BOT_DETECTION_HELPERS.includes(i.name))
+
+    for (const name of BOT_DETECTION_HELPERS) {
+      const entries = botRegistrations.filter(i => i.name === name)
+      expect(entries, `${name} should be registered exactly once`).toHaveLength(1)
+      expect(entries[0]!.from, `${name} should come from the mock composables`).toContain('server/mock-composables')
+    }
+  })
+
+  it('registers each bot detection helper exactly once from the real implementation when botDetection is true', async () => {
+    const registrations = await collectServerImportRegistrations(true)
+    const botRegistrations = registrations.filter(i => BOT_DETECTION_HELPERS.includes(i.name))
+
+    for (const name of BOT_DETECTION_HELPERS) {
+      const entries = botRegistrations.filter(i => i.name === name)
+      expect(entries, `${name} should be registered exactly once`).toHaveLength(1)
+      expect(entries[0]!.from, `${name} should come from the real composables`).toContain('server/composables/getBotDetection')
+      expect(entries[0]!.from).not.toContain('mock')
+    }
+  })
+
+  it('keeps the non bot detection server composables registered in both modes', async () => {
+    for (const botDetection of [false, true]) {
+      const registrations = await collectServerImportRegistrations(botDetection)
+      for (const name of ['getPathRobotConfig', 'getSiteRobotConfig']) {
+        const entries = registrations.filter(i => i.name === name)
+        expect(entries, `${name} should be registered exactly once with botDetection: ${botDetection}`).toHaveLength(1)
+        expect(entries[0]!.from).toContain('server/composables')
+        expect(entries[0]!.from).not.toContain('mock')
+      }
+    }
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

Closes #324

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

From issue #324: with `botDetection: false` the module registered `getBotDetection`, `isBot` and `getBotInfo` twice, once from the scanned `runtime/server/composables` directory and once as mocks. The real implementations won, so the mocks never applied:

```
Duplicated imports "getBotDetection", the one from "@nuxtjs/robots/dist/runtime/server/mock-composables" has been ignored and "@nuxtjs/robots/dist/runtime/server/composables/getBotDetection.js" is used
```

The real `getBotDetection` file is now excluded from the Nitro auto-import scan when detection is disabled, so the mocks are the only registration and the duplicate warnings are gone. With `botDetection: true` nothing changes.

The file stays where it is instead of moving into a separate directory because `#robots/server/composables/getBotDetection` is a documented import path and the `#internal/nuxt-robots` nitro alias points into that directory for sibling modules. One caveat: the exclusion relies on unimport's negative glob support in `imports.dirs` (present in unimport 5.x and 6.x). I could not run a full Nitro production build with `botDetection: false` locally; the e2e fixtures in CI cover the build path.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).